### PR TITLE
RID-1786 remove DRS specific credentials (now supports platform credentials)

### DIFF
--- a/password-authentication-drs/README.md
+++ b/password-authentication-drs/README.md
@@ -18,15 +18,6 @@ Follow the main README to create your application and configure your environment
 Configure the passwords authentication method in your tenant by following
 [this step in the Transmit guide](https://developer.transmitsecurity.com/guides/user/auth_passwords/#step-3-configure-auth-method).
 
-### Configure detection and response services
-
-Update your `.env` file:
-
-- `VITE_TS_DRS_CLIENT_ID` should contain your risk Client ID (Platform Admin Console > Risk >
-  Settings)
-- `TS_DRS_CLIENT_SECRET` should contain your risk Client secret (Platform Admin Console > Risk >
-  Settings)
-
 ## Application features
 
 ### Signup

--- a/password-authentication-drs/README.md
+++ b/password-authentication-drs/README.md
@@ -52,3 +52,5 @@ Platform Admin Console (Risk > Recommendations). Actions:
 When a user performs the `Transaction` action, a recommendation and risk score will be displayed to
 allow the front end client make a real time decision of whether to add friction or remove friction
 to this user's experience.
+
+Actions and recommendations can be seen in the Admin-portal under `Detection and Response > Recommendations` [link](https://portal.identity.security/risk/timeline)

--- a/password-authentication-drs/pages/init.js
+++ b/password-authentication-drs/pages/init.js
@@ -25,8 +25,8 @@ window.drs = {
 
 // Step 2: Load DRS SDK
 document.addEventListener('TSAccountProtectionReady', function () {
-  console.log('TSAccountProtectionReady', window.env.VITE_TS_DRS_CLIENT_ID);
-  window.myTSAccountProtection = new window.TSAccountProtection(window.env.VITE_TS_DRS_CLIENT_ID);
+  console.log('TSAccountProtectionReady', window.env.VITE_TS_CLIENT_ID);
+  window.myTSAccountProtection = new window.TSAccountProtection(window.env.VITE_TS_CLIENT_ID);
   window.myTSAccountProtection.init();
 });
 

--- a/sample.env
+++ b/sample.env
@@ -3,7 +3,7 @@
 # Optional port (default is 8080)
 # PORT=<your port>
 
-# Copy the base codespace URL, and add -8080.preview.app before the github.dev suffix. This is the base launch URL for configurations
+# Copy the base codespace URL, and add -8080.preview.app before the .github.dev suffix. This is the base launch URL for configurations
 TS_REDIRECT_URI=<above-modified-url>/complete
 VITE_TS_CLIENT_ID=<your app client id> # VITE_ prefix allows exposing to client side pages as well as the backend
 TS_CLIENT_SECRET=<your app client secret>

--- a/sample.env
+++ b/sample.env
@@ -12,10 +12,5 @@ TS_APP_ID=<your app ID, will be used by the demo to point you to configuration p
 # SAML idp variables below
 TS_SERVICE_PROVIDER_ID=<your testing service provider for saml idp sample>
 
-
-# Detection and Response variables below
-VITE_TS_DRS_CLIENT_ID=<your risk client id> # VITE_ prefix allows exposing to client side pages as well as the backend
-TS_DRS_CLIENT_SECRET=<your risk client secret>
-
 # Base url/domain to invoke APIs default to non-eu. Uncomment to point to eu domain.
 # VITE_TS_API_BASE=https://api.eu.transmitsecurity.io


### PR DESCRIPTION
Removed references to DRS specific credentials as now application credentials are the recommended means of operation with DRS