### PR TITLE
Return early with error when token fetching fails

### DIFF
--- a/login-with-be-email/backend/index.js
+++ b/login-with-be-email/backend/index.js
@@ -57,7 +57,7 @@ router.post('/send-email-otp', common.utils.rateLimiter(), async function (req, 
       // For more information see https://developer.transmitsecurity.com/guides/user/retrieve_client_tokens/
       accessToken = await common.tokens.getClientCredsToken();
       if (!accessToken) {
-        res.status(500).send({ error: 'could not fetch access token' });
+        return res.status(500).send({ error: 'could not fetch access token' });
       }
 
       // send the OTP email

--- a/login-with-be-magiclink/backend/index.js
+++ b/login-with-be-magiclink/backend/index.js
@@ -56,7 +56,7 @@ router.post('/send-magic-link', common.utils.rateLimiter(), async function (req,
     try {
       accessToken = await common.tokens.getClientCredsToken();
       if (!accessToken) {
-        res.status(500).send({ error: 'could not fetch access token' });
+        return res.status(500).send({ error: 'could not fetch access token' });
       }
 
       // send the magic link

--- a/login-with-be-sms/backend/index.js
+++ b/login-with-be-sms/backend/index.js
@@ -57,7 +57,7 @@ router.post('/send-sms-otp', common.utils.rateLimiter(), async function (req, re
       // For more information see https://developer.transmitsecurity.com/guides/user/retrieve_client_tokens/
       accessToken = await common.tokens.getClientCredsToken();
       if (!accessToken) {
-        res.status(500).send({ error: 'could not fetch access token' });
+        return res.status(500).send({ error: 'could not fetch access token' });
       }
 
       // send the OTP sms

--- a/login-with-email/backend/index.js
+++ b/login-with-email/backend/index.js
@@ -32,7 +32,7 @@ router.post('/email-otp', common.utils.rateLimiter(), async function (req, res) 
       // For more information see https://developer.transmitsecurity.com/guides/user/retrieve_client_tokens/
       accessToken = await common.tokens.getClientCredsToken();
       if (!accessToken) {
-        res.status(500).send({ error: 'could not fetch access token' });
+        return res.status(500).send({ error: 'could not fetch access token' });
       }
 
       // send the OTP email

--- a/login-with-magiclink/backend/index.js
+++ b/login-with-magiclink/backend/index.js
@@ -30,7 +30,7 @@ router.post('/send-magic-link', common.utils.rateLimiter(), async function (req,
     try {
       accessToken = await common.tokens.getClientCredsToken();
       if (!accessToken) {
-        res.status(500).send({ error: 'could not fetch access token' });
+        return res.status(500).send({ error: 'could not fetch access token' });
       }
 
       // send the magic link

--- a/login-with-sms/backend/index.js
+++ b/login-with-sms/backend/index.js
@@ -32,7 +32,7 @@ router.post('/sms-otp', common.utils.rateLimiter(), async function (req, res) {
       // For more information see https://developer.transmitsecurity.com/guides/user/retrieve_client_tokens/
       accessToken = await common.tokens.getClientCredsToken();
       if (!accessToken) {
-        res.status(500).send({ error: 'could not fetch access token' });
+        return res.status(500).send({ error: 'could not fetch access token' });
       }
 
       // send the OTP SMS

--- a/saml-idp/backend/routes/index.js
+++ b/saml-idp/backend/routes/index.js
@@ -66,7 +66,7 @@ router.post('/login-sms/sms-otp', common.utils.rateLimiter(), async function (re
       // For more information see https://developer.transmitsecurity.com/guides/user/retrieve_client_tokens/
       accessToken = await common.tokens.getClientCredsToken();
       if (!accessToken) {
-        res.status(500).send({ error: 'could not fetch access token' });
+        return res.status(500).send({ error: 'could not fetch access token' });
       }
 
       // send the OTP SMS

--- a/webauthn-cross-device-for-logged-in-users/backend/routes/emailOTP.js
+++ b/webauthn-cross-device-for-logged-in-users/backend/routes/emailOTP.js
@@ -31,7 +31,7 @@ router.post('/email-otp', async function (req, res) {
       // For more information see https://developer.transmitsecurity.com/guides/user/retrieve_client_tokens/
       accessToken = await common.tokens.getClientCredsToken();
       if (!accessToken) {
-        res.status(500).send({ error: 'could not fetch access token' });
+        return res.status(500).send({ error: 'could not fetch access token' });
       }
 
       // send the OTP email

--- a/webauthn-for-logged-in-users/backend/routes/emailOTP.js
+++ b/webauthn-for-logged-in-users/backend/routes/emailOTP.js
@@ -32,7 +32,7 @@ router.post('/email-otp', async function (req, res) {
       // For more information see https://developer.transmitsecurity.com/guides/user/retrieve_client_tokens/
       accessToken = await common.tokens.getClientCredsToken();
       if (!accessToken) {
-        res.status(500).send({ error: 'could not fetch access token' });
+        return res.status(500).send({ error: 'could not fetch access token' });
       }
 
       // send the OTP email


### PR DESCRIPTION
In some sample apps, when token fetching fails, the handler didn't return immediately with error, but tried to continue (without success, of course, because there's no access token).

Fix the flow to return immediately when the token fetching fails.
